### PR TITLE
Add binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jkingslake/subglacial-groundwater/add_requirements)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stacylarochelle/subglacial-groundwater/HEAD)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jkingslake/subglacial-groundwater/HEAD)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jkingslake/subglacial-groundwater/HEAD)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jkingslake/subglacial-groundwater/add_requirements)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+matplotlib
+scipy


### PR DESCRIPTION
This adds a link to the README to open the repo in binder. It is in the form of a little Binder badge. 

It also adds a requirements.txt file so that binder knows what packages it needs to install. 

Binder finally opens, but it takes a long time. 

I am not sure how useful binder will be for sharing the code, but I thought I would add it just in case you find it useful at some point. 

For future reference, you can create a binder link and a badge by entering the details in the form at https://mybinder.org/